### PR TITLE
Fix mime type MediaRecorder options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,11 @@ class ReactWebCamCapture extends Component {
   initMediaRecorder = () => {
     try {
       let options = {}
-      let types = ['video/webmcodecs=vp8', 'video/webm', '']
+      let types = [
+        'video/webm;codecs=vp8',
+        'video/webm', 
+        ''
+      ]
 
       if(this.props.mimeType) types.unshift(this.props.mimeType)
 


### PR DESCRIPTION
Video recorded using the orginal ```video/webmcodecs=vp8``` option causes a playback error in Firefox with the following console output:

```
Media resource could not be decoded, error: 
Error Code: NS_ERROR_DOM_MEDIA_METADATA_ERR (0x806e0006)
Details: static MP4Metadata::ResultAndByteBuffer mozilla::MP4Metadata::Metadata(mozilla::ByteStream *): Cannot parse metadata
```

Changing the mime type option according to formatting listed [on Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/isTypeSupported) and 
[on Google](https://developers.google.com/web/updates/2016/01/mediarecorder) seems to solve the issue.